### PR TITLE
#39: Respect base url

### DIFF
--- a/jupyterlab_dotscience/src/index.ts
+++ b/jupyterlab_dotscience/src/index.ts
@@ -1,6 +1,7 @@
 import {
   ILayoutRestorer, JupyterLab, JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+import { PageConfig } from '@jupyterlab/coreutils';
 
 /*
 import {
@@ -18,8 +19,8 @@ import '../style/index.css';
 
 //const API_URL = 'http://127.0.0.1:8000/example.json'
 
-const COMMITS_API_URL = '/dotscience/commits'
-const STATUS_API_URL = '/dotscience/status'
+const COMMITS_API_URL = PageConfig.getBaseURL() + 'dotscience/commits'
+const STATUS_API_URL = PageConfig.getBaseURL() + 'dotscience/status'
 
 type GenericObject = { [key: string]: any };
 

--- a/jupyterlab_dotscience/src/index.ts
+++ b/jupyterlab_dotscience/src/index.ts
@@ -19,8 +19,8 @@ import '../style/index.css';
 
 //const API_URL = 'http://127.0.0.1:8000/example.json'
 
-const COMMITS_API_URL = PageConfig.getBaseURL() + 'dotscience/commits'
-const STATUS_API_URL = PageConfig.getBaseURL() + 'dotscience/status'
+const COMMITS_API_URL = PageConfig.getBaseUrl() + 'dotscience/commits'
+const STATUS_API_URL = PageConfig.getBaseUrl() + 'dotscience/status'
 
 type GenericObject = { [key: string]: any };
 


### PR DESCRIPTION
Fixes #39. Part of https://github.com/dotmesh-io/gateway/issues/410.

Sometimes Jupyter is at different base URL (http://example.com/base/lab rather than http://example.com/lab). This supports that situation.