### PR TITLE
FIX: bump python-sdk -> 0.2.4

### DIFF
--- a/jupyterlab_dotscience_backend/setup.py
+++ b/jupyterlab_dotscience_backend/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/dotmesh-io/jupyterlab-plugin",
     packages=setuptools.find_packages(),
-    install_requires=['datadots-api>=0.2.1'],
+    install_requires=['datadots-api>=0.2.4'],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This bumps the python-sdk import to 0.2.4 to fix the upgraded jsonrpc client response format