### PR TITLE
#51: check there is a match before extracting the value

### DIFF
--- a/jupyterlab_dotscience/src/index.ts
+++ b/jupyterlab_dotscience/src/index.ts
@@ -69,7 +69,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     const saveButton = document.createElement('button')
     saveButton.textContent = "Save and push data"
-    const xsrfToken = document.cookie.match('\\b_xsrf=([^;]*)\\b')[1]
+    const xsrfTokenCookieMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b')
+    const xsrfToken = xsrfTokenCookieMatch && xsrfTokenCookieMatch.length > 1 ? xsrfTokenCookieMatch[1] : ''
     saveButton.addEventListener("click", () => {
       fetch(COMMITNPUSH_API_URL + "?_xsrf=" + xsrfToken, {"method": "PUT"})
         .then(response => {


### PR DESCRIPTION
This prevents the plugin failing to activate if the cookie value is not set